### PR TITLE
Reduced consing in decoder

### DIFF
--- a/cl-jpeg.asd
+++ b/cl-jpeg.asd
@@ -1,6 +1,6 @@
 (asdf:defsystem :cl-jpeg
   :name "cl-jpeg"
-  :version "1.9"
+  :version "2.0"
   :license "BSD"
   :description "A self-contained baseline JPEG codec implementation"
   :author "Eugene Zaikonnikov; contributions by Kenan Bölükbaşı, Manuel Giraud, Cyrus Harmon and William Halliburton"

--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -66,7 +66,7 @@
 
 (in-package #:jpeg)
 
-#+nil(declaim (inline csize write-stuffed quantize get-average zigzag encode-block
+(declaim (inline csize write-stuffed quantize get-average zigzag encode-block
                  llm-dct descale crunch colorspace-convert subsample inverse-llm-dct
                  dequantize upsample extend recieve decode-ac decode-dc decode-block
                  izigzag write-bits))
@@ -111,13 +111,13 @@
   `(the fixnum (- (the fixnum ,a) (the fixnum ,b))))
 
 (defmacro mul (a b)
-  `(the fixnum (* (the fixnum ,a) (the fixnum ,b)))))
+  `(the fixnum (* (the fixnum ,a) (the fixnum ,b))))
 
 (defmacro plus3 (x y z)
   `(plus (plus ,x ,y) ,z))
 
 (defmacro mul3 (x y z)
-  `(mul (mul ,x ,y) ,z))
+  `(mul (mul ,x ,y) ,z)))
 
 ;;; Somewhat silly, but who knows...
 (when (/= (integer-length most-positive-fixnum)

--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -66,7 +66,7 @@
 
 (in-package #:jpeg)
 
-(declaim (inline csize write-stuffed quantize get-average zigzag encode-block
+(declaim (inline csize quantize get-average zigzag
                  llm-dct descale crunch colorspace-convert subsample inverse-llm-dct
                  dequantize upsample extend recieve decode-ac decode-dc decode-block
                  izigzag write-bits))
@@ -756,7 +756,7 @@
 
 ;;; Writes byte with stuffing (adds zero after FF code)
 (defun write-stuffed (b s)
-  (declare #.*optimize* (type fixnum b)
+  (declare #.*optimize* (type uint8 b)
            (type stream s))
    (write-byte b s)
    (if (= b #xFF)


### PR DESCRIPTION
Dramatic improvement to heap allocation in decoder. Decoding a 16Mp image allocates a bit over 49Mbytes, with 48 being the proper RGB data. 4x improvement from v1.9.