### PR TITLE
User-supplied image buffer support and niceties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # cl-jpeg
 Baseline JPEG codec written in Common Lisp.
+
+
+## TODO
+
+* Add progressive JPEG support in decoder

--- a/cl-jpeg.asd
+++ b/cl-jpeg.asd
@@ -1,6 +1,6 @@
 (asdf:defsystem :cl-jpeg
   :name "cl-jpeg"
-  :version "2.0"
+  :version "2.1"
   :license "BSD"
   :description "A self-contained baseline JPEG codec implementation"
   :author "Eugene Zaikonnikov; contributions by Kenan Bölükbaşı, Manuel Giraud, Cyrus Harmon and William Halliburton"

--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -1693,40 +1693,36 @@
                 (setf (aref buffer pv) ; RED
                       (the uint8 (limit (plus yy (aref *cr-r-tab* cr)))))))))
 
-(defun decode-frame-beginning (image s buffer &key (return-meta nil))
+(defun allocate-buffer (height width ncomp)
+  (make-array (* height width ncomp) 
+	      :element-type 'uint8
+	      :initial-element 0))
+
+(defun decode-frame-beginning (image s buffer)
   (read-byte s) ; length
   (read-byte s)
   (read-byte s) ; sample precision
-  (if return-meta
-      (values (setf (descriptor-height image) (read-word s)) ; height
-	      (setf (descriptor-width image) (read-word s))  ; width
-	      (setf (descriptor-ncomp image) (read-byte s)))
-      (if (arrayp buffer)
+  (if (arrayp buffer)
 	  (if (< (length buffer) (* (setf (descriptor-height image) (read-word s)) ; height
 				   (setf (descriptor-width image) (read-word s)) ; width
 				   (setf (descriptor-ncomp image) (read-byte s))))
-	      (error "Invalid buffer supplied: %A" buffer)
+	      (error "Invalid buffer supplied: ~A" buffer)
 	      (setf (descriptor-buffer image) buffer))
 	  (setf (descriptor-buffer image)
-		(make-array (* (setf (descriptor-height image) (read-word s)) ; height
-			       (setf (descriptor-width image) (read-word s)) ; width
-			       (setf (descriptor-ncomp image) (read-byte s))) ; number of components
-			    :element-type 'uint8
-			    :initial-element 0)))))
+		(allocate-buffer (setf (descriptor-height image) (read-word s)) ; height
+				 (setf (descriptor-width image) (read-word s)) ; width
+				 (setf (descriptor-ncomp image) (read-byte s))))))
 
 ;;; Frame decoding subroutine
-(defun decode-frame (image s buffer &key return-meta)
-  (if return-meta
-      (decode-frame-beginning image s buffer :return-meta return-meta)
-      (progn
-	(decode-frame-beginning image s buffer)
-	(loop for i fixnum from 0 below (descriptor-ncomp image)
-	   with hv fixnum do
-	     (setf (aref (descriptor-cid image) i) (read-byte s)) ; Cj
-	     (setf hv (read-byte s))				  ; HV
-	     (setf (aref (descriptor-H image) i) (ash hv -4))
-	     (setf (aref (descriptor-V image) i) (logand hv 7))
-	     (setf (aref (descriptor-qdest image) i) (read-byte s)))
+(defun decode-frame (image s buffer)
+  (decode-frame-beginning image s buffer)
+  (loop for i fixnum from 0 below (descriptor-ncomp image)
+     with hv fixnum do
+       (setf (aref (descriptor-cid image) i) (read-byte s)) ; Cj
+       (setf hv (read-byte s))				    ; HV
+       (setf (aref (descriptor-H image) i) (ash hv -4))
+       (setf (aref (descriptor-V image) i) (logand hv 7))
+       (setf (aref (descriptor-qdest image) i) (read-byte s)))
 	(let* ((frl (loop for i fixnum from 0 below (descriptor-ncomp image)
 		       collecting (list (aref (descriptor-H image) i)
 					(aref (descriptor-V image) i))))
@@ -1744,16 +1740,16 @@
 		 (error "Unsupported marker in the frame header"))
 	       (setf term (decode-scan image j s)))
 	  (when (= (descriptor-ncomp image) 3)
-	    (inverse-colorspace-convert image))))))
+	    (inverse-colorspace-convert image))))
 
-(defun decode-stream (stream buffer &key return-meta)
+(defun decode-stream (stream buffer)
   "Return image array, height, width, and number of components. Does not support
 progressive DCT-based JPEGs."
   (unless (= (read-marker stream) +M_SOI+)
     (error "Unrecognized JPEG format"))
   (let* ((image (make-descriptor))
          (marker (interpret-markers image 0 stream)))
-    (cond ((= +M_SOF0+ marker) (decode-frame image stream buffer :return-meta return-meta)
+    (cond ((= +M_SOF0+ marker) (decode-frame image stream buffer)
            (values (descriptor-buffer image)
                    (descriptor-height image)
                    (descriptor-width image)
@@ -1765,7 +1761,7 @@ progressive DCT-based JPEGs."
   (with-open-file (in filename :direction :input :element-type 'uint8)
     (decode-stream in buffer)))
 
-(defun decode-stream-height-width (stream)
+(defun decode-stream-height-width-ncomp (stream)
   "Return the height and width of the JPEG data read from STREAM. Does less work than
 DECODE-STREAM and also supports progressive DCT-based JPEGs."
   (unless (= (read-marker stream) +M_SOI+)
@@ -1773,12 +1769,13 @@ DECODE-STREAM and also supports progressive DCT-based JPEGs."
   (let* ((image (make-descriptor)) ;; KLUDGE doing a lot of extra consing here
          (marker (interpret-markers image 0 stream)))
     (cond ((or (= +M_SOF0+ marker)
-               (= +M_SOF2+ marker)) (decode-frame-beginning image stream)
+               (= +M_SOF2+ marker)) (decode-frame-beginning image stream nil)
            (values (descriptor-height image)
-                   (descriptor-width image)))
+                   (descriptor-width image)
+		   (descriptor-ncomp image)))
           (t (error "Unsupported JPEG format: ~A" marker)))))
 
 (defun jpeg-file-dimensions (filename)
   "Return image height, width and number of components"
   (with-open-file (in filename :direction :input :element-type 'uint8)
-    (decode-stream in nil :return-meta t)))
+    (decode-stream-height-width-ncomp in)))

--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -1742,7 +1742,7 @@
 	  (when (= (descriptor-ncomp image) 3)
 	    (inverse-colorspace-convert image))))
 
-(defun decode-stream (stream buffer)
+(defun decode-stream (stream &optional buffer)
   "Return image array, height, width, and number of components. Does not support
 progressive DCT-based JPEGs."
   (unless (= (read-marker stream) +M_SOI+)

--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -1697,7 +1697,7 @@
   (read-byte s) ; length
   (read-byte s)
   (read-byte s) ; sample precision
-  (if (return-meta)
+  (if return-meta
       (values (setf (descriptor-height image) (read-word s)) ; height
 	      (setf (descriptor-width image) (read-word s))  ; width
 	      (setf (descriptor-ncomp image) (read-byte s)))
@@ -1781,4 +1781,4 @@ DECODE-STREAM and also supports progressive DCT-based JPEGs."
 (defun jpeg-file-dimensions (filename)
   "Return image height, width and number of components"
   (with-open-file (in filename :direction :input :element-type 'uint8)
-    (decode-stream in buffer :return-meta t)))
+    (decode-stream in nil :return-meta t)))

--- a/package.lisp
+++ b/package.lisp
@@ -3,7 +3,7 @@
   (:nicknames #:cl-jpeg)
   (:export #:encode-image
            #:decode-stream
-           #:decode-stream-height-width
            #:decode-image
+	   #:allocate-buffer
 	   #:jpeg-file-dimensions
            #:jpeg-to-bmp))

--- a/package.lisp
+++ b/package.lisp
@@ -5,4 +5,5 @@
            #:decode-stream
            #:decode-stream-height-width
            #:decode-image
+	   #:jpeg-file-dimensions
            #:jpeg-to-bmp))

--- a/test.lisp
+++ b/test.lisp
@@ -1,5 +1,13 @@
 (in-package #:jpeg)
 
-(time (multiple-value-bind (buf h w nc)
-	  (decode-image #P"/home/eugene/Pictures/nyc.jpg")
-	(encode-image #P"/tmp/test.jpg" buf nc h w)))
+(defun test-reencode (&optional (pathname #P"/home/eugene/Pictures/nyc.jpg"))
+  (time (multiple-value-bind (buf h w nc)
+	    (decode-image pathname)
+	  (encode-image #P"/tmp/test.jpg" buf nc h w))))
+
+(defun test-reencode-prealloc (&optional (pathname #P"/home/eugene/Pictures/nyc.jpg"))
+  (multiple-value-bind (h w ncomp)
+      (jpeg-file-dimensions pathname)
+    (let ((buf (allocate-buffer h w ncomp)))
+      (decode-image pathname buf)
+      (encode-image #P"/tmp/test.jpg" buf ncomp h w))))

--- a/test.lisp
+++ b/test.lisp
@@ -1,0 +1,5 @@
+(in-package #:jpeg)
+
+(time (multiple-value-bind (buf h w nc)
+	  (decode-image #P"/home/eugene/Pictures/nyc.jpg")
+	(encode-image #P"/tmp/test.jpg" buf nc h w)))


### PR DESCRIPTION
DECODE-IMAGE now accepts optional user supplied buffer. ALLOCATE-BUFFER and JPEG-FILE-DIMENSIONS were added to support buffer reuse for handling massive image sets. Rudimentary tests added.