### PR TITLE
Fix for compile time optimization

### DIFF
--- a/cl-jpeg.asd
+++ b/cl-jpeg.asd
@@ -1,6 +1,6 @@
 (asdf:defsystem :cl-jpeg
   :name "cl-jpeg"
-  :version "2.3"
+  :version "2.4"
   :license "BSD"
   :description "A self-contained baseline JPEG codec implementation"
   :author "Eugene Zaikonnikov; contributions by Kenan Bölükbaşı, Manuel Giraud, Cyrus Harmon and William Halliburton"


### PR DESCRIPTION
Compilation was taking forever on Allegro due to loop there being really slow in evaluated mode. Forcing compilation for the loops now, should give more reliable benchmark on other platforms too now.