### PR TITLE
set :COLORSPACE-CONVERSION to default T in DECODE-STREAM

### DIFF
--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -1844,7 +1844,7 @@
 		 (error 'unsupported-jpeg-frame-marker))
 	       (setf term (decode-scan image j s)))))
 
-(defun decode-stream (stream &key buffer colorspace-conversion)
+(defun decode-stream (stream &key buffer (colorspace-conversion t))
   "Return image array, height, width, and number of components. Does not support
 progressive DCT-based JPEGs."
   (unless (= (read-marker stream) +M_SOI+)


### PR DESCRIPTION
last minute fix to preserve backwards-compatibility