### PR TITLE
Version 2.8

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-02-17  Eugene Zaikonnikov  <eugene@funcall.org>
+
+	* Added :CACHED-SOURCE-P option to decoder allowing to read-sequence the image at once
+
 2017-02-16  Eugene Zaikonnikov  <eugene@funcall.org>
 
 	* Added a test for decode only

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2017-02-16  Eugene Zaikonnikov  <eugene@funcall.org>
+
+	* Added a test for decode only
+
+	* Moved IDCT workspace from a special variable into image descriptor to reduce consing
+
 2017-02-07  Eugene Zaikonnikov  <eugene@funcall.org>
 
 	* Added support for descriptor reuse (e.g. in video decoding)

--- a/cl-jpeg.asd
+++ b/cl-jpeg.asd
@@ -1,6 +1,6 @@
 (asdf:defsystem :cl-jpeg
   :name "cl-jpeg"
-  :version "2.7"
+  :version "2.8"
   :license "BSD"
   :description "A self-contained baseline JPEG codec implementation"
   :author "Eugene Zaikonnikov; contributions by Kenan Bölükbaşı, Manuel Giraud, Cyrus Harmon and William Halliburton"

--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -1303,8 +1303,7 @@
 (defun izigzag8 (inbuf zzbuf)
   (declare #.*optimize*
            (type uint8-array inbuf)
-	   (type uint8-2d-array zzbuf)
-	   )
+	   (type uint8-2d-array zzbuf))
   "Performs inverse zigzag block arrangement"
   (loop for zrow across +zigzag-index+
         for row across zzbuf do

--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -1989,9 +1989,9 @@ DECODE-STREAM and also supports progressive DCT-based JPEGs."
 		      (declare #.*optimize*
 			       (type uint8-array cache)
 			       (type fixnum pos))
-		      (prog1 (aref cache pos) (incf pos)))))
+		      (prog1 (the uint8 (aref cache pos)) (incf pos)))))
 	      #'(lambda ()
-		  (read-byte stream))))
+		  (the uint8 (read-byte stream)))))
     (unless (= (read-marker image) +M_SOI+)
       (error 'unrecognized-file-format))
     (let ((marker (interpret-markers image 0)))

--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -1255,12 +1255,14 @@
        '(0  0  0  0  0  0  0  0)
        '(0  0  0  0  0  0  0  0))
       :type sint16-2d-array)	; Temporary workspace for IDCT
-  (byte-reader)
+  (byte-reader #'(lambda () ;in case setup fails somehow
+		   (error 'jpeg-decoder-error)) :type function)
   (source-cache)
   (adobe-app14-transform nil))
 
 (defun read-jpeg-byte (image)
-  (funcall (descriptor-byte-reader image)))
+  (declare #.*optimize*)
+  (the uint8 (funcall (descriptor-byte-reader image))))
 
 ;;; Reads an JPEG marker from the stream
 (defun read-marker (s)

--- a/package.lisp
+++ b/package.lisp
@@ -9,4 +9,5 @@
 	   #:allocate-buffer
 	   #:jpeg-file-dimensions
            #:jpeg-to-bmp
-	   #:descriptor-source-cache))
+	   #:descriptor-source-cache
+	   #:read-dht))

--- a/package.lisp
+++ b/package.lisp
@@ -8,4 +8,5 @@
 	   #:convert-cmyk-to-rgb
 	   #:allocate-buffer
 	   #:jpeg-file-dimensions
-           #:jpeg-to-bmp))
+           #:jpeg-to-bmp
+	   #:descriptor-source-cache))

--- a/test.lisp
+++ b/test.lisp
@@ -5,6 +5,10 @@
 	    (jpeg:decode-image pathname)
 	  (jpeg:encode-image #P"/tmp/test.jpg" buf nc h w))))
 
+(defun test-decode (&optional (pathname #P"/home/eugene/Pictures/nyc.jpg"))
+  (time (jpeg:decode-image pathname))
+  nil)
+
 (defun test-reencode-prealloc (&optional (pathname #P"/home/eugene/Pictures/nyc.jpg"))
   (multiple-value-bind (h w ncomp)
       (jpeg-file-dimensions pathname)

--- a/test.lisp
+++ b/test.lisp
@@ -37,5 +37,5 @@
   (time (with-open-file (stream pathname :direction :input :element-type 'uint8)
     (let ((seq (make-array (file-length stream))))
     (read-sequence seq stream)
-    (flexi-streams:with-input-from-sequence (is seq)  (jpeg:decode-stream is)))))
+    (flexi-streams:with-input-from-sequence (is seq) (jpeg:decode-stream is)))))
   nil)

--- a/test.lisp
+++ b/test.lisp
@@ -1,12 +1,20 @@
 (cl:in-package :jpeg)
 
-(defun test-reencode (&optional (pathname #P"/home/eugene/Pictures/nyc.jpg"))
+(defun test-reencode (&key (pathname #P"/home/eugene/Pictures/nyc.jpg") cached)
   (time (multiple-value-bind (buf h w nc)
-	    (jpeg:decode-image pathname)
+	    (jpeg:decode-image pathname :cached-source-p cached)
 	  (jpeg:encode-image #P"/tmp/test.jpg" buf nc h w))))
 
-(defun test-decode (&optional (pathname #P"/home/eugene/Pictures/nyc.jpg"))
-  (time (jpeg:decode-image pathname))
+(defun test-decode (&key (pathname #P"/home/eugene/Pictures/nyc.jpg") cached)
+  (time (jpeg:decode-image pathname :cached-source-p cached))
+  nil)
+
+(defun test-decode-reuse (&key (pathname #P"/home/eugene/Pictures/nyc.jpg"))
+  (let ((d (make-descriptor)))
+    (with-open-file (stream pathname :direction :input :element-type 'uint8)
+      (time (jpeg:decode-stream stream :cached-source-p t :descriptor d)))
+    (with-open-file (stream pathname :direction :input :element-type 'uint8)
+      (time (jpeg:decode-stream stream :cached-source-p t :descriptor d))))
   nil)
 
 (defun test-reencode-prealloc (&optional (pathname #P"/home/eugene/Pictures/nyc.jpg"))
@@ -24,3 +32,10 @@
     (let ((buf (make-array (* width height) :initial-element 42)))
       (time (jpeg:encode-image output buf 1 width height
                           :q-tabs *gray-q-tabs*)))))
+
+(defun test-flexi-decode (&optional (pathname #P"/home/eugene/Pictures/nyc.jpg"))
+  (time (with-open-file (stream pathname :direction :input :element-type 'uint8)
+    (let ((seq (make-array (file-length stream))))
+    (read-sequence seq stream)
+    (flexi-streams:with-input-from-sequence (is seq)  (jpeg:decode-stream is)))))
+  nil)

--- a/test.lisp
+++ b/test.lisp
@@ -17,11 +17,11 @@
       (time (jpeg:decode-stream stream :cached-source-p t :descriptor d))))
   nil)
 
-(defun test-reencode-prealloc (&optional (pathname #P"/home/eugene/Pictures/nyc.jpg"))
+(defun test-reencode-prealloc (&key (pathname #P"/home/eugene/Pictures/nyc.jpg") cached)
   (multiple-value-bind (h w ncomp)
       (jpeg-file-dimensions pathname)
     (let ((buf (allocate-buffer h w ncomp)))
-      (decode-image pathname buf)
+      (decode-image pathname :buffer buf :cached-source-p cached)
       (encode-image #P"/tmp/test.jpg" buf ncomp h w))))
 
 (defparameter *gray-q-tabs* (vector jpeg::+q-luminance+))


### PR DESCRIPTION
- :cached-source-p flag now allows decoder to operate on a buffer cached in descriptor than via direct read-bytes from a stream. Should improve batch processing and video decoding performance a bit.
- IDCT workspace moved from a speical var into descriptor as well.

The above gives about 15% speedup on SBCL in batch processing.