### PR TITLE
in decode-stream, use descriptor-byte-reader, if supplied

### DIFF
--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -1949,25 +1949,27 @@ progressive DCT-based JPEGs."
 	       (scan-y scan) 0)))
   (let* ((image (or descriptor (make-descriptor)))
 	 (pos 0))
-    (unless (and descriptor
-                 (descriptor-byte-reader descriptor))
-      (setf (descriptor-byte-reader image)
-            (if cached-source-p
-                (progn
-                  (when (or (not (typep (descriptor-source-cache image) 'array))
-                            (and (typep stream 'file-stream) (< (length (descriptor-source-cache image)) (file-length stream))))
-                    (setf (descriptor-source-cache image) (make-array (file-length stream) :element-type 'uint8)))
-                  (when stream ;; NULL stream means the cache in descriptor is already read
-                    (read-sequence (descriptor-source-cache image) stream))
-                  (let ((cache (descriptor-source-cache image)))
-                    #'(lambda ()
-                        (declare #.*optimize*
-                                 (type uint8-array cache)
-                                 (type fixnum pos))
-                        (prog1 (aref cache pos) (incf pos)))))
-                #'(lambda ()
-                    (read-byte stream)))))
-    (unless (= (read-marker image) +M_SOI+)
+    (cond (cached-source-p
+           (when (or (not (typep (descriptor-source-cache image) 'array))
+                     (and (typep stream 'file-stream) (< (length (descriptor-source-cache image)) (file-length stream))))
+             (setf (descriptor-source-cache image) (make-array (file-length stream) :element-type 'uint8)))
+           (when stream ;; NULL stream means the cache in descriptor is already read
+             (read-sequence (descriptor-source-cache image) stream))
+           (let ((cache (descriptor-source-cache image)))
+             (setf (descriptor-byte-reader image)
+                   #'(lambda ()
+                       (declare #.*optimize*
+                                (type uint8-array cache)
+                                (type fixnum pos))
+                       (prog1 (aref cache pos) (incf pos))))))
+          ;; if descriptor is NULL or the descriptor's byte-reader is
+          ;; NULL, set it here.
+          ((or (not descriptor)
+               (not (descriptor-byte-reader descriptor)))
+           (setf (descriptor-byte-reader image)
+                 #'(lambda ()
+                     (read-byte stream)))))
+     (unless (= (read-marker image) +M_SOI+)
       (error 'unrecognized-file-format))
     (let ((marker (interpret-markers image 0)))
       (cond ((= +M_SOF0+ marker)


### PR DESCRIPTION
 * previously, we would always make a new dsecriptor, even if we
   passed one in via the descriptor kw arg. Now we use that, if
   supplied.

   BTW, all of this code is kind of a mess and there's a major OOAO
   violation between decode-stream and
   decode-stream-height-width-ncomp (which doesn't have this
   fix). Perhaps we should clean this all up a bit.