### PR TITLE
check that we have a stream before calling file-length

### DIFF
--- a/jpeg.lisp
+++ b/jpeg.lisp
@@ -1950,18 +1950,23 @@ progressive DCT-based JPEGs."
   (let* ((image (or descriptor (make-descriptor)))
 	 (pos 0))
     (cond (cached-source-p
-           (when (or (not (typep (descriptor-source-cache image) 'array))
-                     (and (typep stream 'file-stream) (< (length (descriptor-source-cache image)) (file-length stream))))
-             (setf (descriptor-source-cache image) (make-array (file-length stream) :element-type 'uint8)))
-           (when stream ;; NULL stream means the cache in descriptor is already read
-             (read-sequence (descriptor-source-cache image) stream))
-           (let ((cache (descriptor-source-cache image)))
-             (setf (descriptor-byte-reader image)
-                   #'(lambda ()
-                       (declare #.*optimize*
-                                (type uint8-array cache)
-                                (type fixnum pos))
-                       (prog1 (aref cache pos) (incf pos))))))
+           ;; if stream is a file-stream we know how to cache the
+           ;; source, but if not, we don't so we just punt and rely on
+           ;; the descriptor's supplied byte-reader to do the work
+           (when stream
+             (when (or (not (typep (descriptor-source-cache image) 'array))
+                       (and (< (length (descriptor-source-cache image))
+                               (file-length stream))))
+               (setf (descriptor-source-cache image)
+                     (make-array (file-length stream) :element-type 'uint8)))
+             (read-sequence (descriptor-source-cache image) stream)
+             (let ((cache (descriptor-source-cache image)))
+               (setf (descriptor-byte-reader image)
+                     #'(lambda ()
+                         (declare #.*optimize*
+                                  (type uint8-array cache)
+                                  (type fixnum pos))
+                         (prog1 (aref cache pos) (incf pos)))))))
           ;; if descriptor is NULL or the descriptor's byte-reader is
           ;; NULL, set it here.
           ((or (not descriptor)


### PR DESCRIPTION
 * in decode stream, which is a bit of a misnomer, if cached-source-p
   was true, we would check for the cached source buffer, and if it
   didn't exist, we would attempt to create a cache buffer. But
   there's a (perhaps perverse) use case where decode-stream is called
   with a null-stream, but with a byte-reader that does the work. This
   is what retrospectiff uses to read JPEG encoded TIFF images. So, to
   guard against this, check that stream is not NIL before calling
   file-length on the stream. This will still file if one tries to
   pass in a non "stream associated with a file", but that seems less
   bad.